### PR TITLE
Attendees fix when fetching Meetup Events

### DIFF
--- a/src/main/java/gamebot/CoreHelpers.java
+++ b/src/main/java/gamebot/CoreHelpers.java
@@ -89,6 +89,11 @@ public class CoreHelpers {
 	protected Member getUserById(long id) {
 		return getGuild().getMembers().filter(p -> p.getId().asLong() == id).next().block();
 	}
+	
+	protected String getUserIfMentionable(long id) {
+		Member member = getUserById(id);
+		return member != null ? member.getMention() : "";
+	}
 
 	protected Member convertUserToMember(long id) {
 		return cli.getUserById(Snowflake.of(id)).block().asMember(Snowflake.of(SERVER)).block();

--- a/src/main/java/gamebot/IntervalListener.java
+++ b/src/main/java/gamebot/IntervalListener.java
@@ -132,7 +132,7 @@ public class IntervalListener extends CoreHelpers {
 		logMessage("Found "+attendees.size()+" attendees for event "+eventId+" to append");
 		for(Pair<String, String> attendee : attendees) {
 			Long userId = MeetupLinker.getUserByMeetupId(new Long(attendee.second()));		
-			list += attendee.first() + (userId != 0L ? ": "+getUserById(userId).getMention() : "") +"\n";
+			list += attendee.first() + (userId != 0L ? ": "+getUserIfMentionable(userId) : "") +"\n";
 		}
 		return list;
 	}

--- a/src/main/java/meetup/MeetupEvent.java
+++ b/src/main/java/meetup/MeetupEvent.java
@@ -49,6 +49,15 @@ public class MeetupEvent {
 	}
 
 	public String getDate() {
+		/**
+		 * Split Date: 
+		 * #0 = Day (3 char)
+		 * #1 = Month (3 char)
+		 * #2 = Day of Month
+		 * #3 = Year
+		 * #5 = Time
+		 * #6 = AM/PM  
+		 */
 		String[] splitDate = startDateTime.split(", | ");
 		String parseableDate = splitDate[0].substring(0, 3) + ", " + splitDate[2] + " " + splitDate[1].substring(0, 3)
 				+ " " + splitDate[3] + " " + convertAmPm(splitDate[5], splitDate[6]) + " GMT";

--- a/src/main/java/meetup/MeetupEventManager.java
+++ b/src/main/java/meetup/MeetupEventManager.java
@@ -37,6 +37,7 @@ public class MeetupEventManager {
 		}).map(o -> o.second()).collect(Collectors.toCollection(ArrayList::new));
 		events.removeIf(o -> toRemove.contains(o.second()));
 		log.info("Found "+toRemove.size()+ ", Events list now contains "+events.size());
+		saveEventData();
 		return toRemove;
 	}
 	

--- a/src/main/java/meetup/SeleniumDriver.java
+++ b/src/main/java/meetup/SeleniumDriver.java
@@ -92,7 +92,7 @@ public class SeleniumDriver {
 
 	public long sendCode(String meetupUrl, String code) {
 		lock();
-		long meetupId = new Long(extractIdFromMeetupUrl(meetupUrl));
+		long meetupId = new Long(extractIdFromMeetupUrl(meetupUrl)).longValue();
 		try {
 			webDriver.get(meetupUrl);
 			Element("//a[contains(@id, 'message-link')]").click();


### PR DESCRIPTION
- Added a getUserIfMentionable to Core Helpers which should return empty instead of breaking if a user can no longer be reached (e.g has left the server or deleted their account)
- Added a comment so I can remember how the date parsing works when it inevitably breaks again
- Save the events file when items are removed from the list, not sure why I left that out